### PR TITLE
chore(release): v1.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## [1.3.4](https://github.com/easy-form/react-form-simple/compare/v1.3.3...v1.3.4) (2023-12-25)
+
+
+### Bug Fixes
+
+* Fix label type error and add support for label passing in ReactNode type ([647e97c](https://github.com/easy-form/react-form-simple/commit/647e97cedd88e5e9ae19bcc684d1b5ce793bf722))
+
+
+### Features
+
+* Adding form atomic components can add style class names externally. ([6e5fa57](https://github.com/easy-form/react-form-simple/commit/6e5fa57bfe4bd903479879559d13c73a2876e29c))
+
+
+
 # Changelog
 
 ## [1.3.3](https://github.com/easy-form/react-form-simple/compare/v1.3.2...v1.3.3) (2023-12-25)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,106 +1,86 @@
-## [1.3.4](https://github.com/easy-form/react-form-simple/compare/v1.3.3...v1.3.4) (2023-12-25)
+# Changelog
 
+## [1.3.4](https://github.com/easy-form/react-form-simple/compare/v1.3.3...v1.3.4) (2023-12-25)
 
 ### Bug Fixes
 
-* Fix label type error and add support for label passing in ReactNode type ([647e97c](https://github.com/easy-form/react-form-simple/commit/647e97cedd88e5e9ae19bcc684d1b5ce793bf722))
-
+- Fix label type error and add support for label passing in ReactNode type ([647e97c](https://github.com/easy-form/react-form-simple/commit/647e97cedd88e5e9ae19bcc684d1b5ce793bf722))
 
 ### Features
 
-* Adding form atomic components can add style class names externally. ([6e5fa57](https://github.com/easy-form/react-form-simple/commit/6e5fa57bfe4bd903479879559d13c73a2876e29c))
-
-
-
-# Changelog
+- Adding form atomic components can add style class names externally. ([6e5fa57](https://github.com/easy-form/react-form-simple/commit/6e5fa57bfe4bd903479879559d13c73a2876e29c))
 
 ## [1.3.3](https://github.com/easy-form/react-form-simple/compare/v1.3.2...v1.3.3) (2023-12-25)
 
-
 ### Bug Fixes
 
-* fix a bug in the invalid direction setting of the Form component ([8c8d989](https://github.com/easy-form/react-form-simple/commit/8c8d98933ea38391b088a583c0fa924e20746816))
-
+- fix a bug in the invalid direction setting of the Form component ([8c8d989](https://github.com/easy-form/react-form-simple/commit/8c8d98933ea38391b088a583c0fa924e20746816))
 
 ### Features
 
-* add wxchat group code image ([6e64869](https://github.com/easy-form/react-form-simple/commit/6e6486938b93b0017a5171064215b649c5667627))
-* update group imgage ([e3378f8](https://github.com/easy-form/react-form-simple/commit/e3378f88e8759b7aefa8498cd1d32124ea44e062))
-
-
+- add wxchat group code image ([6e64869](https://github.com/easy-form/react-form-simple/commit/6e6486938b93b0017a5171064215b649c5667627))
+- update group imgage ([e3378f8](https://github.com/easy-form/react-form-simple/commit/e3378f88e8759b7aefa8498cd1d32124ea44e062))
 
 ## [1.3.2](https://github.com/easy-form/react-form-simple/compare/v1.3.1...v1.3.2) (2023-12-13)
 
-
 ### Bug Fixes
 
-* typo for `destroy` ([#31](https://github.com/easy-form/react-form-simple/issues/31)) ([c6c4421](https://github.com/easy-form/react-form-simple/commit/c6c442198920c2cc11b8c99d54b9e7964f240f67))
-
-
+- typo for `destroy` ([#31](https://github.com/easy-form/react-form-simple/issues/31)) ([c6c4421](https://github.com/easy-form/react-form-simple/commit/c6c442198920c2cc11b8c99d54b9e7964f240f67))
 
 ## [1.3.1](https://github.com/easy-form/react-form-simple/compare/v1.3.0...v1.3.1) (2023-12-11)
 
-
 ### Bug Fixes
 
-* fix types ([0ce34d2](https://github.com/easy-form/react-form-simple/commit/0ce34d2021e3b54fd020bd4de4ea600b6ad00a1f))
-
+- fix types ([0ce34d2](https://github.com/easy-form/react-form-simple/commit/0ce34d2021e3b54fd020bd4de4ea600b6ad00a1f))
 
 ## [1.3.0](https://github.com/easy-form/react-form-simple/compare/v1.2.0...v1.3.0) (2023-12-08)
 
-
 ### Features
 
-* add Form Item setError API ([c43f6e0](https://github.com/easy-form/react-form-simple/commit/c43f6e0b3b5221b86b77eec23c6aadf7b23b2a51))
-* add setError API ([1397503](https://github.com/easy-form/react-form-simple/commit/1397503cadb8b1bfab5f772b36eefbe241c2b326))
+- add Form Item setError API ([c43f6e0](https://github.com/easy-form/react-form-simple/commit/c43f6e0b3b5221b86b77eec23c6aadf7b23b2a51))
+- add setError API ([1397503](https://github.com/easy-form/react-form-simple/commit/1397503cadb8b1bfab5f772b36eefbe241c2b326))
 
 ## [1.2.0](https://github.com/easy-form/react-form-simple/compare/v1.1.0...v1.2.0) (2023-11-29)
 
-
 ### Features
 
-* v1.1.1 ([603098a](https://github.com/easy-form/react-form-simple/commit/603098a7aad4116db273c01bf06071d7f99418b9))
+- v1.1.1 ([603098a](https://github.com/easy-form/react-form-simple/commit/603098a7aad4116db273c01bf06071d7f99418b9))
 
 ## [1.1.0](https://github.com/easy-form/react-form-simple/compare/v1.0.0...v1.1.0) (2023-11-16)
 
-
 ### Features
 
-* add firsr release version ([263e112](https://github.com/easy-form/react-form-simple/commit/263e112a2ac45b5e6948e0cc284a1c781042826a))
+- add firsr release version ([263e112](https://github.com/easy-form/react-form-simple/commit/263e112a2ac45b5e6948e0cc284a1c781042826a))
 
 ## [1.0.0](https://github.com/easy-form/react-form-simple/compare/v0.2.0...v1.0.0) (2023-11-16)
 
-
 ### ⚠ BREAKING CHANGES
 
-* first release version
+- first release version
 
 ### Features
 
-* add first release version v1.2.0 ([3eda5c4](https://github.com/easy-form/react-form-simple/commit/3eda5c49ab1b1bb0b98b5db2b95a1daa919ce3a0))
+- add first release version v1.2.0 ([3eda5c4](https://github.com/easy-form/react-form-simple/commit/3eda5c49ab1b1bb0b98b5db2b95a1daa919ce3a0))
 
 ## [0.2.0](https://github.com/easy-form/react-form-simple/compare/v0.1.0...v0.2.0) (2023-11-16)
 
-
 ### Features
 
-* add v1.10.0 ([7dd44e8](https://github.com/easy-form/react-form-simple/commit/7dd44e8b9faecf6c8d0953787ec3e8e2b1ef0646))
-* add v1.10.0 ([daf11db](https://github.com/easy-form/react-form-simple/commit/daf11dbe927f429cd73603025b76d8c0c8b8c455))
-* update version ([8ce9e53](https://github.com/easy-form/react-form-simple/commit/8ce9e53d96cf8f17bac1caeb4e7a89e0d0443965))
+- add v1.10.0 ([7dd44e8](https://github.com/easy-form/react-form-simple/commit/7dd44e8b9faecf6c8d0953787ec3e8e2b1ef0646))
+- add v1.10.0 ([daf11db](https://github.com/easy-form/react-form-simple/commit/daf11dbe927f429cd73603025b76d8c0c8b8c455))
+- update version ([8ce9e53](https://github.com/easy-form/react-form-simple/commit/8ce9e53d96cf8f17bac1caeb4e7a89e0d0443965))
 
 ## [0.1.0](https://github.com/easy-form/react-form-simple/compare/v0.0.1...v0.1.0) (2023-11-16)
 
-
 ### Features
 
-* add v1.1.0 or release or tag ([1322195](https://github.com/easy-form/react-form-simple/commit/1322195bdb6ae6a93f47a8232c6619b7124c96ad))
-* add v1.1.0 or release or tags ([4b136e0](https://github.com/easy-form/react-form-simple/commit/4b136e0cae79d3efb706504831977a2c7484de80))
-* add v1.1.0 or tag or release ([c7428c2](https://github.com/easy-form/react-form-simple/commit/c7428c2b6e3bdf8c6dc5ca1b1671e98e8c07c304))
-* add v1.10.0 or release or tag ([271d8c1](https://github.com/easy-form/react-form-simple/commit/271d8c15dd254178217b95b49c1ee9bd77bd1cd7))
-* add v1.10.0 or release or tag ([554e22b](https://github.com/easy-form/react-form-simple/commit/554e22b0733244dbe4be09afbceebc8e38ada434))
-* add workflow ([8381abb](https://github.com/easy-form/react-form-simple/commit/8381abb070abe5e0b81738e9eb7556a181c0441e))
-
+- add v1.1.0 or release or tag ([1322195](https://github.com/easy-form/react-form-simple/commit/1322195bdb6ae6a93f47a8232c6619b7124c96ad))
+- add v1.1.0 or release or tags ([4b136e0](https://github.com/easy-form/react-form-simple/commit/4b136e0cae79d3efb706504831977a2c7484de80))
+- add v1.1.0 or tag or release ([c7428c2](https://github.com/easy-form/react-form-simple/commit/c7428c2b6e3bdf8c6dc5ca1b1671e98e8c07c304))
+- add v1.10.0 or release or tag ([271d8c1](https://github.com/easy-form/react-form-simple/commit/271d8c15dd254178217b95b49c1ee9bd77bd1cd7))
+- add v1.10.0 or release or tag ([554e22b](https://github.com/easy-form/react-form-simple/commit/554e22b0733244dbe4be09afbceebc8e38ada434))
+- add workflow ([8381abb](https://github.com/easy-form/react-form-simple/commit/8381abb070abe5e0b81738e9eb7556a181c0441e))
 
 ### Bug Fixes
 
-* actions ([#3](https://github.com/easy-form/react-form-simple/issues/3)) ([e201ff4](https://github.com/easy-form/react-form-simple/commit/e201ff49b5a5763591a266785f5278530a9ed6d3))
+- actions ([#3](https://github.com/easy-form/react-form-simple/issues/3)) ([e201ff4](https://github.com/easy-form/react-form-simple/commit/e201ff49b5a5763591a266785f5278530a9ed6d3))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-form-simple",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "A form library for quickly controlling react form input",
   "keywords": [
     "react",


### PR DESCRIPTION
### Bug Fixes

- Fix label type error and add support for label passing in ReactNode type ([647e97c](https://github.com/easy-form/react-form-simple/commit/647e97cedd88e5e9ae19bcc684d1b5ce793bf722))

### Features

- Adding form atomic components can add style class names externally. ([6e5fa57](https://github.com/easy-form/react-form-simple/commit/6e5fa57bfe4bd903479879559d13c73a2876e29c))